### PR TITLE
fix：修改HMapHeader的Format常量 解决无法正确处理大小端自序的问题

### DIFF
--- a/lib/hmap/hmap/hmap_struct.rb
+++ b/lib/hmap/hmap/hmap_struct.rb
@@ -69,7 +69,7 @@ module HMap
     #  or nil if the HMapHeader was created via {create}.
     attr_reader :num_entries, :magic, :version, :reserved, :strings_offset, :num_buckets, :max_value_length
 
-    FORMAT = 'L=1S=2L4'
+    FORMAT = 'L=1S=2L=4'
     # @see HMapStructure::SIZEOF
     # @api private
     SIZEOF = 24


### PR DESCRIPTION
如果使用原先的format，L默认使用大端方式解码。会导致读取数据有误